### PR TITLE
Add Azure deployment step to CI/CD

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -41,3 +41,18 @@ jobs:
         run: |
           cd script
           python deployment_test.py
+
+  deploy-to-azure:
+    needs: test-deployment  # Wait for testing job to complete
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy to Azure Function App
+        uses: Azure/functions-action@v1
+        with:
+          app-name: heymate-popularity-func  # Your Azure Function App name
+          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}
+          package: ./script # Deploy from root (adjust if function app is in subfolder)


### PR DESCRIPTION
This pull request adds a CI/CD deployment step to the GitHub Actions workflow.
It builds on the existing environment setup and introduces Azure Function App deployment using the functions-action@v1

Appends a new job deploy-to-azure to the .github/workflows/deployment.ym
Uses the AZURE_FUNCTIONAPP_PUBLISH_PROFILE secret to deploy
Publishes the full repo as an Azure Function App named heymate-popularity-func